### PR TITLE
Include muspan optional extra dependency

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,28 @@
+# Installation Guide
+
+To install the most basic version of this project, create a python virtual environment
+and run:
+
+```bash
+pip install git+https://github.com/ImperialCollegeLondon/ReCoDe-spatial-transcriptomics.git
+```
+
+However, there are some analysis modules that use the tool `MuSpAn`, which requires a
+license to install. If you want to use those modules, you will need to request a
+license. Do this by following the link in the [MuSpAn installation instructions]. Once
+you have your username and password, run the following command and enter them when
+prompted.
+
+```bash
+pip install 'recode_st[muspan] @ git+https://github.com/ImperialCollegeLondon/ReCoDe-spatial-transcriptomics.git'
+```
+
+[MuSpAn installation instructions]: https://docs.muspan.co.uk/latest/Installation.html
+
+## Development installation
+
+To install the development version of the software, clone this repo and run
+
+```bash
+pip install -e ".[dev,muspan]"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "pytest-cov",
     "pytest-mock",
 ]
+muspan = ["muspan @ https://docs.muspan.co.uk/code/latest.zip"]
 
 [tool.pytest.ini_options]
 addopts = "-v -p no:warnings --cov=src --cov-report=html --doctest-modules --ignore=src/recode_spatial_transcriptomics/__main__.py --ignore=docs/ --ignore=utils/"

--- a/src/recode_st/6_muspan.py
+++ b/src/recode_st/6_muspan.py
@@ -20,6 +20,15 @@ logger = getLogger(__name__)
 
 def run_muspan():
     """Run Muspan on Xenium data."""
+    try:
+        import muspan  # noqa: F401
+    except ModuleNotFoundError as err:
+        logger.error(
+            "Could not load necessary MuSpAn package. You can obtain this with:\n"
+            "    pip install 'recode_st[muspan] @ git+"
+            "https://github.com/ImperialCollegeLondon/ReCoDe-spatial-transcriptomics.git"
+        )
+        raise err
     # Set variables
     module_name = "6_muspan"  # name of the module
     module_dir = output_path / module_name


### PR DESCRIPTION
I have added MuSpAn to the dependencies, but since it requires a license, I have included it as an optional extra and provided some documentation to explain how to install it.

This docs page should be moved to wherever makes the most sense for the final exemplar website.

Close #56 