### PR TITLE
Remove taplo-lint for inexplicable failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,3 @@ repos:
     rev: v0.9.3
     hooks:
       - id: taplo-format # Format TOML files
-      - id: taplo-lint


### PR DESCRIPTION
Is failing in CI of unexplained reasons and the linter is never really doing anyway anyway.