### PR TITLE
Add some tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for the config module."""
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -15,6 +17,38 @@ def test_config():
 
     assert config.log_level == "INFO"
     assert config.seed == 42
+
+
+def test_io_config_resolve_paths(tmp_path):
+    """Test that the IOConfig can be created and has default values."""
+    from recode_st.config import IOConfig
+
+    with pytest.raises(ValidationError):
+        IOConfig(base_dir="non_existent_directory")
+
+    # Check that the default paths are set correctly
+    io_config = IOConfig()
+
+    assert io_config.base_dir == Path()
+    assert io_config.data_dir == Path() / "data"
+    assert io_config.output_dir == Path() / "analysis"
+    assert io_config.xenium_dir == Path() / "data" / "xenium"
+    assert io_config.zarr_dir == Path() / "data" / "xenium.zarr"
+    assert io_config.area_path == Path() / "data" / "selected_cells_stats.csv"
+    assert io_config.logging_dir == Path() / "analysis" / "logs"
+
+    # Check that paths outside of the base directory are resolved correctly
+    base_dir = tmp_path / "base"
+    base_dir.mkdir()
+    io_config = IOConfig(base_dir=base_dir, data_dir=tmp_path / "data")
+
+    assert io_config.base_dir == base_dir
+    assert io_config.data_dir == tmp_path / "data"
+    assert io_config.output_dir == base_dir / "analysis"
+    assert io_config.xenium_dir == tmp_path / "data" / "xenium"
+    assert io_config.zarr_dir == tmp_path / "data" / "xenium.zarr"
+    assert io_config.area_path == tmp_path / "data" / "selected_cells_stats.csv"
+    assert io_config.logging_dir == base_dir / "analysis" / "logs"
 
 
 def test_load_config(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,7 +39,7 @@ def test_io_config_resolve_paths(tmp_path):
 
     # Check that paths outside of the base directory are resolved correctly
     base_dir = tmp_path / "base"
-    base_dir.mkdir()
+    base_dir.mkdir(parents=True, exist_ok=True)
     io_config = IOConfig(base_dir=base_dir, data_dir=tmp_path / "data")
 
     assert io_config.base_dir == base_dir

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,43 @@
+"""Tests for the config module."""
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_config():
+    """Test that the configuration can be created and has default values."""
+    from recode_st.config import Config
+
+    with pytest.raises(ValidationError):
+        Config()
+
+    config = Config(seed=42)
+
+    assert config.log_level == "INFO"
+    assert config.seed == 42
+
+
+def test_load_config(tmp_path):
+    """Test loading configuration from a file."""
+    from recode_st.config import load_config
+
+    # Check that an error is raised for a non-existent config file
+    with pytest.raises(ValueError):
+        load_config("non_existent_config.toml")
+
+    # Check that an error is raised for an empty config file
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("", encoding="utf-8")
+
+    with pytest.raises(ValidationError):
+        load_config(config_file)
+
+    # Check that a valid config file can be loaded
+    config_file.write_text(
+        f"seed=42\nlog_level='DEBUG'\n[io]\nbase_dir='{tmp_path}'", encoding="utf-8"
+    )
+    config = load_config(config_file)
+
+    assert config.seed == 42
+    assert config.log_level == "DEBUG"
+    assert config.io.base_dir == tmp_path

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,32 @@
+"""Test for the logging_config module."""
+
+import logging
+from pathlib import Path
+
+
+def test_configure_logging(tmp_path, caplog):
+    """Test that logging is configured correctly."""
+    from recode_st.logging_config import configure_logging
+
+    # Create a temporary directory for logging
+    logging_dir = tmp_path / "logs"
+    logging_dir.mkdir(parents=True, exist_ok=True)
+
+    # Configure logging
+    configure_logging(logging_dir, "DEBUG")
+
+    # Check if the logger is set up correctly
+    logger = logging.getLogger("recode_st")
+    logger.debug("Test debug message.")
+    log_file = Path(logger.handlers[-1].baseFilename)
+
+    assert logger.name == "recode_st"
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 2
+    assert log_file == next(logging_dir.glob("*"))
+    assert caplog.record_tuples[-1] == (
+        "recode_st",
+        logging.DEBUG,
+        "Test debug message.",
+    )
+    assert log_file.read_text().endswith(" - recode_st - DEBUG] Test debug message.\n")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,7 @@ def test_main(mocker, caplog):
     )
 
     configure_logging_mock = mocker.patch("recode_st.logging_config.configure_logging")
+    seed_everything_mock = mocker.patch("recode_st.helper_function.seed_everything")
 
     # Test with no modules enabled in config
     config = Config(seed=42)
@@ -20,6 +21,7 @@ def test_main(mocker, caplog):
     configure_logging_mock.assert_called_once_with(
         config.io.logging_dir, config.log_level
     )
+    seed_everything_mock.assert_called_once_with(config.seed)
     assert caplog.record_tuples == [
         ("recode_st", 20, "Seeding everything..."),
         ("recode_st", 20, "Starting recode_st pipeline..."),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -31,6 +31,7 @@ def test_main(mocker, caplog):
     convert_xenium_to_zarr_mock = mocker.patch(
         "recode_st.format_data.convert_xenium_to_zarr"
     )
+    run_qc_mock = mocker.patch("recode_st.qc.run_qc")
     config.modules.format_data = FormatDataModuleConfig(module_name="0_format")
     with caplog.at_level("INFO"):
         main(config)
@@ -38,6 +39,7 @@ def test_main(mocker, caplog):
     convert_xenium_to_zarr_mock.assert_called_once_with(
         config.io.xenium_dir, config.io.zarr_dir
     )
+    run_qc_mock.assert_not_called()
     assert caplog.record_tuples[-2:] == [
         ("recode_st", 20, "Running Module 0 - Format"),
         ("recode_st.format_data", 20, "Finished formatting data."),
@@ -61,6 +63,7 @@ def test_main(mocker, caplog):
     run_spatial_statistics_mock.assert_called_once_with(
         config.modules.spatial_statistics, config.io
     )
+    run_qc_mock.assert_not_called()
     assert caplog.record_tuples[-3:] == [
         ("recode_st", 20, "Running Module 0 - Format"),
         ("recode_st.format_data", 20, "Finished formatting data."),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,66 @@
+"""Tests for the __main__ module."""
+
+
+def test_main(mocker, caplog):
+    """Test that the main function runs without errors."""
+    from recode_st.__main__ import main
+    from recode_st.config import (
+        Config,
+        FormatDataModuleConfig,
+        SpatialStatisticsModuleConfig,
+    )
+
+    configure_logging_mock = mocker.patch("recode_st.logging_config.configure_logging")
+
+    # Test with no modules enabled in config
+    config = Config(seed=42)
+    with caplog.at_level("INFO"):
+        main(config)
+
+    configure_logging_mock.assert_called_once_with(
+        config.io.logging_dir, config.log_level
+    )
+    assert caplog.record_tuples == [
+        ("recode_st", 20, "Seeding everything..."),
+        ("recode_st", 20, "Starting recode_st pipeline..."),
+    ]
+
+    # Test with format_data module enabled
+    convert_xenium_to_zarr_mock = mocker.patch(
+        "recode_st.format_data.convert_xenium_to_zarr"
+    )
+    config.modules.format_data = FormatDataModuleConfig(module_name="0_format")
+    with caplog.at_level("INFO"):
+        main(config)
+
+    convert_xenium_to_zarr_mock.assert_called_once_with(
+        config.io.xenium_dir, config.io.zarr_dir
+    )
+    assert caplog.record_tuples[-2:] == [
+        ("recode_st", 20, "Running Module 0 - Format"),
+        ("recode_st.format_data", 20, "Finished formatting data."),
+    ]
+
+    # Test with format_data and spatial_statistics modules enabled
+    convert_xenium_to_zarr_mock.reset_mock()
+    run_spatial_statistics_mock = mocker.patch(
+        "recode_st.spatial_statistics.run_spatial_statistics"
+    )
+    config.modules.spatial_statistics = SpatialStatisticsModuleConfig(
+        module_name="5_spatial_stats"
+    )
+
+    with caplog.at_level("INFO"):
+        main(config)
+
+    convert_xenium_to_zarr_mock.assert_called_once_with(
+        config.io.xenium_dir, config.io.zarr_dir
+    )
+    run_spatial_statistics_mock.assert_called_once_with(
+        config.modules.spatial_statistics, config.io
+    )
+    assert caplog.record_tuples[-3:] == [
+        ("recode_st", 20, "Running Module 0 - Format"),
+        ("recode_st.format_data", 20, "Finished formatting data."),
+        ("recode_st", 20, "Running Module 5 - Spatial Statistics"),
+    ]


### PR DESCRIPTION
This PR adds some example tests. They are:

Config module tests:
- A test that the `Config` class initialises correctly (truly the pydantic models don't need a lot of testing because we trust that pydantic does its job correctly).
- A test for how the `IOConfig` resolves paths
- A test for the `load_config` function

Main module test. A single test for the `main` function that:
- Confirms logging and seeding is done
- Confirms that only modules included in the config are run

Logging config tests:
- Confirms the logging is set up correctly

Close #89 